### PR TITLE
Sam dev new heuristics

### DIFF
--- a/Part B/AlphaBetaPlayer2.py
+++ b/Part B/AlphaBetaPlayer2.py
@@ -25,7 +25,7 @@ class Player():
     _color: PlayerColor
     # The depth to go in each iteration of the iterative-deepening search
     # algorithm i.e. number of moves to look ahead.
-    _depth: int = 1
+    _depth: int = 2
 
     def __init__(self, color: str):
         """

--- a/Part B/AlphaBetaPlayerAggressive.py
+++ b/Part B/AlphaBetaPlayerAggressive.py
@@ -138,7 +138,7 @@ class Player():
             # Movement.
             assert(self._board.phase == GamePhase.MOVEMENT)
 
-            deltas = self._board.get_valid_movements(positions[0])
+            deltas = self._board.get_possible_deltas(positions[0])
 
             for delta in deltas:
                 if delta.move_target.pos == positions[1]:

--- a/Part B/AlphaBetaPlayerAttackDefend.py
+++ b/Part B/AlphaBetaPlayerAttackDefend.py
@@ -139,7 +139,7 @@ class Player():
             # Movement.
             assert(self._board.phase == GamePhase.MOVEMENT)
 
-            deltas = self._board.get_valid_movements(positions[0])
+            deltas = self._board.get_possible_deltas(positions[0])
 
             for delta in deltas:
                 if delta.move_target.pos == positions[1]:

--- a/Part B/AlphaBetaPlayerDefensive.py
+++ b/Part B/AlphaBetaPlayerDefensive.py
@@ -139,7 +139,7 @@ class Player():
             # Movement.
             assert(self._board.phase == GamePhase.MOVEMENT)
 
-            deltas = self._board.get_valid_movements(positions[0])
+            deltas = self._board.get_possible_deltas(positions[0])
 
             for delta in deltas:
                 if delta.move_target.pos == positions[1]:

--- a/Part B/AlphaBetaPlayerSquads.py
+++ b/Part B/AlphaBetaPlayerSquads.py
@@ -143,7 +143,7 @@ class Player():
             # Movement.
             assert(self._board.phase == GamePhase.MOVEMENT)
 
-            deltas = self._board.get_valid_movements(positions[0])
+            deltas = self._board.get_possible_deltas(positions[0])
 
             for delta in deltas:
                 if delta.move_target.pos == positions[1]:


### PR DESCRIPTION
Added a few more heuristics that I have no idea if they are actually effective

- **Aggressive**: Simply attempts to _reduce distance_ between enemy pieces and friendly pieces (as used in Part A)
- **Defensive**: Attempts to _preserve it's own pieces until the board begins to shrink_, in which case it begins to _move towards the center of the board_.
- **AttackDefend**: Uses the _Aggressive strategy until the board begins to shrink_, in which case it begins to move towards the center of the board.
- **Squads**: Attempts to _group pieces into N size squads_ which will _stay together_ in an attempt to not die. (Note: had to modify board with another method to retrieve a "block") <- No idea if this is working

On a side note, using a higher weighting towards your own pieces seems to result in more survivability and more win, so I've begun to use 1.1 as a standard weighting